### PR TITLE
Prevent segmentation failure when rendering hearts in the hud

### DIFF
--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -32,7 +32,10 @@ void Hud::Render() const {
             HEARTS[4]->Render(vec2f(5 + 16 * i, 5));
             health -= 4;
         } else {
-            HEARTS[health]->Render(vec2f(5 + 16 * i, 5));
+            if (health >= 0) {
+                HEARTS[health]->Render(vec2f(5 + 16 * i, 5));
+            }
+
             health = 0;
         }
     }


### PR DESCRIPTION
Prevent segmentation fault error when rendering hearts in the HUD
![image](https://github.com/user-attachments/assets/10066179-c71f-4d64-8c6b-1b9e376a37f3)

<p align="center">
  <img src="https://github.com/user-attachments/assets/f596d944-ee40-4f87-a670-3958332a698c">
</p>